### PR TITLE
ParkFindHeader component

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,8 @@
 module.exports = {
   preset: 'jest-expo',
   transformIgnorePatterns: [
-    'node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|@sentry/.*)',
+    'node_modules/(?!(jest-)?react-native|@react-navigation/*|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|@sentry/.*)',
   ],
   setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
+  setupFiles: ['<rootDir>/jest/setup.js'],
 }

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -1,0 +1,23 @@
+import 'react-native-gesture-handler/jestSetup'
+
+jest.mock('react-native-reanimated', () => {
+  const Reanimated = require('react-native-reanimated/mock')
+
+  // The mock for `call` immediately calls the callback which is incorrect
+  // So we override it with a no-op
+  Reanimated.default.call = () => {}
+
+  return Reanimated
+})
+
+// Silence the warning: Animated: `useNativeDriver` is not supported because the native animated module is missing
+jest.mock('react-native/Libraries/Animated/src/NativeAnimatedHelper')
+
+jest.mock('@react-navigation/native', () => {
+  return {
+    ...jest.requireActual('@react-navigation/native'),
+    useNavigation: () => ({
+      navigate: jest.fn(),
+    }),
+  }
+})

--- a/src/components/ParkFindHeader.js
+++ b/src/components/ParkFindHeader.js
@@ -1,0 +1,47 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { useNavigation } from '@react-navigation/native'
+import {
+  Header,
+  Search,
+  Content,
+  ParkCount,
+  FilterText,
+  FilterButton,
+} from './ParkFindHeader.styles'
+
+const ParkFindHeader = ({ searchTerm, onChangeText, onSearch, count = 0 }) => {
+  const navigation = useNavigation()
+
+  const parkCountText = `${count} park${count === 1 ? '' : 's'} showing`
+
+  return (
+    <Header>
+      <Search
+        inputStyle={{ fontFamily: 'bcsans' }}
+        value={searchTerm}
+        onChangeText={onChangeText}
+        onIconPress={onSearch}
+      />
+      <Content>
+        <ParkCount>{parkCountText}</ParkCount>
+        <FilterText>Filter</FilterText>
+        <FilterButton
+          icon="tune"
+          size={18}
+          onPress={navigation.toggleDrawer}
+          accessibilityLabel={'Filter Parks'}
+        />
+      </Content>
+    </Header>
+  )
+}
+
+ParkFindHeader.propTypes = {
+  searchTerm: PropTypes.string.isRequired,
+  onChangeText: PropTypes.func.isRequired,
+  onSearch: PropTypes.func.isRequired,
+  count: PropTypes.number,
+}
+
+export default ParkFindHeader

--- a/src/components/ParkFindHeader.js
+++ b/src/components/ParkFindHeader.js
@@ -13,7 +13,7 @@ import {
 const ParkFindHeader = ({ searchTerm, onChangeText, onSearch, count = 0 }) => {
   const navigation = useNavigation()
 
-  const parkCountText = `${count} park${count === 1 ? '' : 's'} showing`
+  const parkCountText = `${count} matching park${count === 1 ? '' : 's'}`
 
   return (
     <Header>

--- a/src/components/ParkFindHeader.styles.js
+++ b/src/components/ParkFindHeader.styles.js
@@ -1,0 +1,39 @@
+import styled from 'styled-components/native'
+import { View } from 'react-native'
+import { Searchbar, Text, IconButton } from 'react-native-paper'
+import theme from '../utils/theme'
+
+export const Header = styled(View)`
+  background-color: white;
+  height: 100px;
+  padding: 20px 30px 0 30px;
+`
+
+export const Search = styled(Searchbar)`
+  border-radius: 10px;
+  elevation: 0;
+  border: 1px solid #828282;
+  height: 37px;
+`
+
+export const Content = styled(View)`
+  flex: 1;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+`
+
+export const ParkCount = styled(Text)`
+  color: ${theme.colors.grey3};
+  margin-right: auto;
+`
+
+export const FilterText = styled(Text)`
+  font-size: 16px;
+  opacity: 0.6;
+`
+
+export const FilterButton = styled(IconButton)`
+  opacity: 0.6;
+  margin-right: -4px;
+`

--- a/src/components/ParkFindHeader.test.js
+++ b/src/components/ParkFindHeader.test.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import renderSnapshot from 'react-test-renderer'
+import ParkFindHeader from './ParkFindHeader'
+
+test('Should render using props', () => {
+  const { getByText } = render(
+    <ParkFindHeader count={48} onChangeText={() => {}} onSearch={() => {}} />
+  )
+
+  const title = getByText('48 parks showing')
+
+  expect(title).toBeDefined()
+})
+
+test('Should use the singular "park"', () => {
+  const { getByText } = render(
+    <ParkFindHeader count={1} onChangeText={() => {}} onSearch={() => {}} />
+  )
+
+  const title = getByText('1 park showing')
+
+  expect(title).toBeDefined()
+})
+
+test('Matches snapshot', () => {
+  const tree = renderSnapshot
+    .create(
+      <ParkFindHeader count={4} onChangeText={() => {}} onSearch={() => {}} />
+    )
+    .toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/ParkFindHeader.test.js
+++ b/src/components/ParkFindHeader.test.js
@@ -8,7 +8,7 @@ test('Should render using props', () => {
     <ParkFindHeader count={48} onChangeText={() => {}} onSearch={() => {}} />
   )
 
-  const title = getByText('48 parks showing')
+  const title = getByText('48 matching parks')
 
   expect(title).toBeDefined()
 })
@@ -18,7 +18,7 @@ test('Should use the singular "park"', () => {
     <ParkFindHeader count={1} onChangeText={() => {}} onSearch={() => {}} />
   )
 
-  const title = getByText('1 park showing')
+  const title = getByText('1 matching park')
 
   expect(title).toBeDefined()
 })

--- a/src/components/__snapshots__/ParkFindHeader.test.js.snap
+++ b/src/components/__snapshots__/ParkFindHeader.test.js.snap
@@ -268,7 +268,7 @@ exports[`Matches snapshot 1`] = `
         ]
       }
     >
-      4 parks showing
+      4 matching parks
     </Text>
     <Text
       style={

--- a/src/components/__snapshots__/ParkFindHeader.test.js.snap
+++ b/src/components/__snapshots__/ParkFindHeader.test.js.snap
@@ -1,0 +1,385 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Matches snapshot 1`] = `
+<View
+  style={
+    Array [
+      Object {
+        "backgroundColor": "white",
+        "height": 100,
+        "paddingBottom": 0,
+        "paddingLeft": 30,
+        "paddingRight": 30,
+        "paddingTop": 20,
+      },
+    ]
+  }
+>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#ffffff",
+        "borderColor": "#828282",
+        "borderRadius": 10,
+        "borderStyle": "solid",
+        "borderWidth": 1,
+        "elevation": 0,
+        "flexDirection": "row",
+        "height": 37,
+      }
+    }
+  >
+    <View
+      accessibilityLabel="search"
+      accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
+      accessible={true}
+      focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 6,
+          "left": 6,
+          "right": 6,
+          "top": 6,
+        }
+      }
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+              "margin": 6,
+              "overflow": "hidden",
+            },
+            Object {
+              "borderRadius": 18,
+              "height": 36,
+              "width": 36,
+            },
+            undefined,
+            undefined,
+          ],
+        ]
+      }
+    >
+      <View>
+        <Text
+          accessibilityElementsHidden={true}
+          allowFontScaling={false}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          style={
+            Array [
+              Object {
+                "color": "rgba(0, 0, 0, 0.54)",
+                "fontSize": 24,
+              },
+              Array [
+                Object {
+                  "transform": Array [
+                    Object {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                Object {
+                  "backgroundColor": "transparent",
+                },
+              ],
+              Object {
+                "fontFamily": "material-community",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+    <TextInput
+      accessibilityRole="search"
+      accessibilityTraits="search"
+      allowFontScaling={true}
+      keyboardAppearance="light"
+      onChangeText={[Function]}
+      placeholder=""
+      placeholderTextColor="rgba(0, 0, 0, 0.54)"
+      rejectResponderTermination={true}
+      returnKeyType="search"
+      selectionColor="#6200ee"
+      style={
+        Array [
+          Object {
+            "alignSelf": "stretch",
+            "flex": 1,
+            "fontSize": 18,
+            "minWidth": 0,
+            "paddingLeft": 8,
+            "textAlign": "left",
+          },
+          Object {
+            "color": "#000000",
+            "fontFamily": "System",
+            "fontWeight": "400",
+          },
+          Object {
+            "fontFamily": "bcsans",
+          },
+        ]
+      }
+      underlineColorAndroid="transparent"
+    />
+    <View
+      accessibilityLabel="clear"
+      accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "disabled": true,
+        }
+      }
+      accessible={true}
+      focusable={true}
+      hitSlop={
+        Object {
+          "bottom": 6,
+          "left": 6,
+          "right": 6,
+          "top": 6,
+        }
+      }
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+              "margin": 6,
+              "overflow": "hidden",
+            },
+            Object {
+              "borderRadius": 18,
+              "height": 36,
+              "width": 36,
+            },
+            Object {
+              "opacity": 0.32,
+            },
+            undefined,
+          ],
+        ]
+      }
+    >
+      <View>
+        <Text
+          accessibilityElementsHidden={true}
+          allowFontScaling={false}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          style={
+            Array [
+              Object {
+                "color": "rgba(255, 255, 255, 0)",
+                "fontSize": 24,
+              },
+              Array [
+                Object {
+                  "transform": Array [
+                    Object {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                Object {
+                  "backgroundColor": "transparent",
+                },
+              ],
+              Object {
+                "fontFamily": "material-community",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "flexBasis": 0,
+          "flexDirection": "row",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "justifyContent": "flex-end",
+        },
+      ]
+    }
+  >
+    <Text
+      style={
+        Array [
+          Object {
+            "color": "#000000",
+            "fontFamily": "System",
+            "fontWeight": "400",
+            "textAlign": "left",
+          },
+          Array [
+            Object {
+              "color": "#828282",
+              "marginRight": "auto",
+            },
+          ],
+        ]
+      }
+    >
+      4 parks showing
+    </Text>
+    <Text
+      style={
+        Array [
+          Object {
+            "color": "#000000",
+            "fontFamily": "System",
+            "fontWeight": "400",
+            "textAlign": "left",
+          },
+          Array [
+            Object {
+              "fontSize": 16,
+              "opacity": 0.6,
+            },
+          ],
+        ]
+      }
+    >
+      Filter
+    </Text>
+    <View
+      accessibilityLabel="Filter Parks"
+      accessibilityRole="button"
+      accessibilityState={
+        Object {
+          "disabled": undefined,
+        }
+      }
+      accessible={true}
+      focusable={false}
+      hitSlop={
+        Object {
+          "bottom": 6,
+          "left": 6,
+          "right": 6,
+          "top": 6,
+        }
+      }
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Array [
+          Object {
+            "overflow": "hidden",
+          },
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+              "margin": 6,
+              "overflow": "hidden",
+            },
+            Object {
+              "borderRadius": 13.5,
+              "height": 27,
+              "width": 27,
+            },
+            undefined,
+            Array [
+              Object {
+                "marginRight": -4,
+                "opacity": 0.6,
+              },
+            ],
+          ],
+        ]
+      }
+    >
+      <View>
+        <Text
+          accessibilityElementsHidden={true}
+          allowFontScaling={false}
+          importantForAccessibility="no-hide-descendants"
+          pointerEvents="none"
+          style={
+            Array [
+              Object {
+                "color": "#000000",
+                "fontSize": 18,
+              },
+              Array [
+                Object {
+                  "transform": Array [
+                    Object {
+                      "scaleX": 1,
+                    },
+                  ],
+                },
+                Object {
+                  "backgroundColor": "transparent",
+                },
+              ],
+              Object {
+                "fontFamily": "material-community",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              Object {},
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -30,6 +30,7 @@ const theme = {
     selected: '#309D9C',
     favorited: '#DA71B7',
     error: '#FF0C3E',
+    grey3: '#828282',
   },
   fonts: configureFonts(fontConfig),
 }


### PR DESCRIPTION
## Screenshots

### Android
<kbd><img src="https://user-images.githubusercontent.com/15054821/96656316-64f48a00-12f4-11eb-9bb2-9f0da3bb79f6.png" width="250" /></kbd> <kbd><img src="https://user-images.githubusercontent.com/15054821/96656365-80f82b80-12f4-11eb-9fc4-e69639c87e36.png" width="250" /></kbd>

### iOS

<kbd><img src="https://user-images.githubusercontent.com/15054821/96657730-d124bd00-12f7-11eb-896e-e7207318d377.PNG" width="250" /></kbd> <kbd><img src="https://user-images.githubusercontent.com/15054821/96657726-cec26300-12f7-11eb-8dab-44eb52b3e63a.PNG" width="250" /></kbd>

## Notes
- As you can see Android and iOS handle the keyboard behaviour differently. Android automatically implements a view as "keyboard avoiding" whereas iOS chooses to display the keyboard over top of the screen.


[Resolves pe1154](https://app.clubhouse.io/parks/story/1154/parkfindpage-header)