### PR TITLE
Remove scroll indicators on the Explore Page and convert the bottom nav bar to the dark theme

### DIFF
--- a/src/navigation/TabNavigator.js
+++ b/src/navigation/TabNavigator.js
@@ -20,8 +20,10 @@ const TabNavigator = () => {
         tabBarLabel: ({ color }) => <Label color={color}>{route.name}</Label>,
       })}
       tabBarOptions={{
-        activeTintColor: theme.colors.selected,
-        inactiveTintColor: theme.colors.disabled,
+        activeBackgroundColor: theme.colors.primary,
+        inactiveBackgroundColor: theme.colors.primary,
+        activeTintColor: 'white',
+        inactiveTintColor: theme.colors.whiteDisabled,
       }}>
       <Tab.Screen
         name="Explore"

--- a/src/pages/Explore.js
+++ b/src/pages/Explore.js
@@ -83,7 +83,7 @@ const Explore = () => {
 
   return (
     <ExplorePage>
-      <ExploreScrollView>
+      <ExploreScrollView showsVerticalScrollIndicator={false}>
         <ExploreHeader source={headerBackgroundSrc}>
           <ExploreSvg width="234" height="28" />
           <RisingSun source={risingSunSrc} />
@@ -96,6 +96,7 @@ const Explore = () => {
         />
         <ExploreSection
           horizontal={true}
+          showsHorizontalScrollIndicator={false}
           data={hikingParks}
           keyExtractor={(item) => item.ORCSSite}
           renderItem={({ item, index }) => (
@@ -126,6 +127,7 @@ const Explore = () => {
         />
         <ExploreSection
           horizontal={true}
+          showsHorizontalScrollIndicator={false}
           data={swimmingParks}
           keyExtractor={(item) => item.ORCSSite}
           renderItem={({ item, index }) => (
@@ -156,6 +158,7 @@ const Explore = () => {
         />
         <ExploreSection
           horizontal={true}
+          showsHorizontalScrollIndicator={false}
           data={vehicleCampingParks}
           keyExtractor={(item) => item.ORCSSite}
           renderItem={({ item, index }) => (

--- a/src/pages/__snapshots__/Explore.test.js.snap
+++ b/src/pages/__snapshots__/Explore.test.js.snap
@@ -15,6 +15,7 @@ exports[`Explore page matches snapshot 1`] = `
   }
 >
   <RCTScrollView
+    showsVerticalScrollIndicator={false}
     style={
       Array [
         Object {
@@ -227,6 +228,7 @@ exports[`Explore page matches snapshot 1`] = `
         removeClippedSubviews={false}
         renderItem={[Function]}
         scrollEventThrottle={50}
+        showsHorizontalScrollIndicator={false}
         stickyHeaderIndices={Array []}
         style={
           Array [
@@ -390,6 +392,7 @@ exports[`Explore page matches snapshot 1`] = `
         removeClippedSubviews={false}
         renderItem={[Function]}
         scrollEventThrottle={50}
+        showsHorizontalScrollIndicator={false}
         stickyHeaderIndices={Array []}
         style={
           Array [
@@ -553,6 +556,7 @@ exports[`Explore page matches snapshot 1`] = `
         removeClippedSubviews={false}
         renderItem={[Function]}
         scrollEventThrottle={50}
+        showsHorizontalScrollIndicator={false}
         stickyHeaderIndices={Array []}
         style={
           Array [

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -29,6 +29,7 @@ const theme = {
     background: '#FFF',
     selected: '#E3A82B',
     disabled: 'rgba(0,0,0,0.53)',
+    whiteDisabled: 'rgba(255,255,255,0.5)',
     favorited: '#DA71B7',
     error: '#FF0C3E',
     grey3: '#828282',


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/15054821/97919379-8ef27700-1d0c-11eb-9d9f-bcf038abe3a3.jpeg" width="250" />

Resolves [pe1466](https://app.clubhouse.io/parks/story/1466/remove-scroll-indicator-on-the-horizontal-scrolling-carousels-and-the-vertical-scrollview-on-the-explore-page)
Resolves part of [pe1316](https://app.clubhouse.io/parks/story/1316/color-theme)
