### PR TITLE
Tweak styling to adapt more gracefully to accessibility font scaling

### DIFF
--- a/src/components/CarouselCard.js
+++ b/src/components/CarouselCard.js
@@ -54,7 +54,7 @@ function CarouselCard({
       </CardCover>
       <CardContent>
         <ContentLine>
-          <ParkTitle>{entities.decode(title)}</ParkTitle>
+          <ParkTitle numberOfLines={3}>{entities.decode(title)}</ParkTitle>
           <MCIcon
             name={favorited ? 'heart' : 'heart-outline'}
             size={20}

--- a/src/components/CarouselCard.styles.js
+++ b/src/components/CarouselCard.styles.js
@@ -18,7 +18,7 @@ export const CardCover = styled(ImageBackground)`
 export const CardBanner = styled(Text)`
   background-color: ${(props) =>
     props.alert ? theme.colors.alert : theme.colors.secondary50};
-  height: 30px;
+  min-height: 30px;
   line-height: 30px;
   text-align: center;
   color: ${(props) => (props.alert ? 'white' : 'black')};

--- a/src/components/CarouselHeader.styles.js
+++ b/src/components/CarouselHeader.styles.js
@@ -9,6 +9,7 @@ export const Container = styled(View)`
   flex-direction: row;
   align-items: center;
   margin-left: 20px;
+  flex-wrap: wrap;
 `
 
 export const Title = styled(PaperTitle)`

--- a/src/components/ParkFindHeader.styles.js
+++ b/src/components/ParkFindHeader.styles.js
@@ -5,7 +5,7 @@ import theme from '../utils/theme'
 
 export const Header = styled(View)`
   background-color: white;
-  height: 100px;
+  min-height: 100px;
   padding: 20px 30px 0 30px;
 `
 
@@ -17,7 +17,8 @@ export const Search = styled(Searchbar)`
 `
 
 export const Content = styled(View)`
-  flex: 1;
+  flex-grow: 1;
+  flex-wrap: wrap;
   flex-direction: row;
   justify-content: flex-end;
   align-items: center;

--- a/src/components/__snapshots__/CarouselCard.test.js.snap
+++ b/src/components/__snapshots__/CarouselCard.test.js.snap
@@ -109,6 +109,7 @@ exports[`renders with no uri and favorited set to true 1`] = `
         }
       >
         <Text
+          numberOfLines={3}
           style={
             Array [
               Object {

--- a/src/components/__snapshots__/ParkFindHeader.test.js.snap
+++ b/src/components/__snapshots__/ParkFindHeader.test.js.snap
@@ -6,7 +6,7 @@ exports[`Matches snapshot 1`] = `
     Array [
       Object {
         "backgroundColor": "white",
-        "height": 100,
+        "minHeight": 100,
         "paddingBottom": 0,
         "paddingLeft": 30,
         "paddingRight": 30,
@@ -241,10 +241,9 @@ exports[`Matches snapshot 1`] = `
       Array [
         Object {
           "alignItems": "center",
-          "flexBasis": 0,
           "flexDirection": "row",
           "flexGrow": 1,
-          "flexShrink": 1,
+          "flexWrap": "wrap",
           "justifyContent": "flex-end",
           "position": "relative",
         },

--- a/src/navigation/TabNavigator.js
+++ b/src/navigation/TabNavigator.js
@@ -16,7 +16,11 @@ const TabNavigator = () => {
   return (
     <Tab.Navigator
       screenOptions={({ route }) => ({
-        tabBarLabel: ({ color }) => <Label color={color}>{route.name}</Label>,
+        tabBarLabel: ({ color }) => (
+          <Label allowFontScaling={false} color={color}>
+            {route.name}
+          </Label>
+        ),
       })}
       tabBarOptions={{
         activeBackgroundColor: theme.colors.primary,

--- a/src/pages/Filter.js
+++ b/src/pages/Filter.js
@@ -22,6 +22,11 @@ import {
 
 function Filter({ navigation }) {
   const theme = useTheme()
+  /*
+   * A way of handling the font-scaling of the Large Accessibility Sizes
+   * feature with a relative position footer
+   */
+  const [footerHeight, setFooterHeight] = React.useState(70)
   const {
     distance,
     setDistance,
@@ -52,7 +57,9 @@ function Filter({ navigation }) {
         <MCIcon onPress={close} name="window-close" size={25} />
       </Header>
 
-      <FilterScrollView showsVerticalScrollIndicator={false}>
+      <FilterScrollView
+        showsVerticalScrollIndicator={false}
+        footerHeight={footerHeight}>
         <Section>
           <FilterTitle>Distance</FilterTitle>
           <MultiSlider
@@ -117,7 +124,10 @@ function Filter({ navigation }) {
         </Section>
       </FilterScrollView>
 
-      <Footer>
+      <Footer
+        onLayout={({ nativeEvent }) =>
+          setFooterHeight(nativeEvent.layout.height)
+        }>
         <Button compact={true} onPress={resetFilters}>
           Clear All
         </Button>
@@ -127,7 +137,7 @@ function Filter({ navigation }) {
             mode={'contained'}
             color={theme.colors.primary50}
             contentStyle={{
-              height: 40,
+              minHeight: 40,
             }}
             labelStyle={{
               fontFamily: 'bcsans-bold',

--- a/src/pages/Filter.styles.js
+++ b/src/pages/Filter.styles.js
@@ -18,7 +18,7 @@ export const Header = styled(View)`
 
 export const FilterScrollView = styled(ScrollView)`
   padding: 10px;
-  margin-bottom: 70px;
+  margin-bottom: ${(props) => props.footerHeight}px;
 `
 
 export const Section = styled(View)`
@@ -34,6 +34,7 @@ export const FilterTitle = styled(Text)`
 export const DistanceMarker = styled(View)`
   align-items: center;
   position: relative;
+  width: 100px;
 `
 
 export const DistanceText = styled(Text)`
@@ -41,10 +42,12 @@ export const DistanceText = styled(Text)`
   position: absolute;
   top: 9px;
   font-size: 10px;
+  text-shadow-color: 'rgba(0, 0, 0, 0.75)';
+  text-shadow-radius: 2px;
 `
 
 export const Footer = styled(View)`
-  height: 70px;
+  min-height: 70px;
   width: 100%;
   border-top-width: 1px;
   border-style: solid;
@@ -53,6 +56,7 @@ export const Footer = styled(View)`
   bottom: 0;
   flex-direction: row;
   align-items: center;
+  flex-wrap: wrap;
   justify-content: space-between;
   padding: 10px;
   background-color: white;

--- a/src/pages/__snapshots__/Explore.test.js.snap
+++ b/src/pages/__snapshots__/Explore.test.js.snap
@@ -86,6 +86,7 @@ exports[`Explore page matches snapshot 1`] = `
             Object {
               "alignItems": "center",
               "flexDirection": "row",
+              "flexWrap": "wrap",
               "marginLeft": 20,
             },
           ]
@@ -246,6 +247,7 @@ exports[`Explore page matches snapshot 1`] = `
             Object {
               "alignItems": "center",
               "flexDirection": "row",
+              "flexWrap": "wrap",
               "marginLeft": 20,
             },
           ]
@@ -406,6 +408,7 @@ exports[`Explore page matches snapshot 1`] = `
             Object {
               "alignItems": "center",
               "flexDirection": "row",
+              "flexWrap": "wrap",
               "marginLeft": 20,
             },
           ]

--- a/src/pages/__snapshots__/Filter.test.js.snap
+++ b/src/pages/__snapshots__/Filter.test.js.snap
@@ -38,6 +38,7 @@ exports[`Filter page matches snapshot 1`] = `
     />
   </View>
   <RCTScrollView
+    footerHeight={70}
     showsVerticalScrollIndicator={false}
     style={
       Array [
@@ -208,6 +209,7 @@ exports[`Filter page matches snapshot 1`] = `
                         Object {
                           "alignItems": "center",
                           "position": "relative",
+                          "width": 100,
                         },
                       ]
                     }
@@ -227,6 +229,8 @@ exports[`Filter page matches snapshot 1`] = `
                               "color": "white",
                               "fontSize": 10,
                               "position": "absolute",
+                              "textShadowColor": "'rgba(0, 0, 0, 0.75)'",
+                              "textShadowRadius": 2,
                               "top": 9,
                             },
                           ],
@@ -338,6 +342,7 @@ exports[`Filter page matches snapshot 1`] = `
     </View>
   </RCTScrollView>
   <View
+    onLayout={[Function]}
     style={
       Array [
         Object {
@@ -348,8 +353,9 @@ exports[`Filter page matches snapshot 1`] = `
           "borderTopWidth": 1,
           "bottom": 0,
           "flexDirection": "row",
-          "height": 70,
+          "flexWrap": "wrap",
           "justifyContent": "space-between",
+          "minHeight": 70,
           "paddingBottom": 10,
           "paddingLeft": 10,
           "paddingRight": 10,
@@ -521,7 +527,7 @@ exports[`Filter page matches snapshot 1`] = `
                   "justifyContent": "center",
                 },
                 Object {
-                  "height": 40,
+                  "minHeight": 40,
                 },
               ]
             }


### PR DESCRIPTION
Resolves [ch-1673](https://app.clubhouse.io/parks/story/1673/accessibility-fixes)

## Notes

- These are quick and dirty fixes that allow the content to still be visible even if they are not super elegant.
- Interesting, the `<Icons />` aren't affected by the font-scaling.

> In terms of a technical resolution this is the best we can do within the constraints of the design. There is perhaps some more, long-term design modifications but we're calling this complete from an "as a bug" angle.

## Screenshots

<kbd><img src="https://user-images.githubusercontent.com/15054821/98731219-42351e80-2352-11eb-8c9b-b8ab245b3130.PNG" width="250" /></kbd> <kbd><img src="https://user-images.githubusercontent.com/15054821/98731232-46f9d280-2352-11eb-862f-3702a82e9b55.PNG" width="250" /></kbd>
<kbd><img src="https://user-images.githubusercontent.com/15054821/98731234-47926900-2352-11eb-826f-c9bf75232682.PNG" width="250" /></kbd> <kbd><img src="https://user-images.githubusercontent.com/15054821/98731235-47926900-2352-11eb-95d7-88ec295f64f4.PNG" width="250" /></kbd>
