### PR TITLE
Ensure the app functions even if a user chooses to deny Location permissions

### DIFF
--- a/__mocks__/expo-location.js
+++ b/__mocks__/expo-location.js
@@ -7,4 +7,10 @@ function getCurrentPositionAsync() {
   }
 }
 
-export { getCurrentPositionAsync }
+function getPermissionsAsync() {
+  return {
+    status: 'granted',
+  }
+}
+
+export { getCurrentPositionAsync, getPermissionsAsync }

--- a/app.json
+++ b/app.json
@@ -17,7 +17,10 @@
     "assetBundlePatterns": ["**/*"],
     "ios": {
       "bundleIdentifier": "ca.bcparks.parks-adventure-mobile",
-      "buildNumber": "0.0.1"
+      "buildNumber": "0.0.1",
+      "infoPlist": {
+        "NSLocationWhenInUseUsageDescription": "This app uses the users location to filter their results based on proximity.",
+      }
     },
     "android": {
       "package": "ca.bcparks.parks_adventure_mobile",

--- a/src/components/LocationBanner.js
+++ b/src/components/LocationBanner.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { DataContext } from '../utils/DataContext'
+import { Portal } from 'react-native-paper'
+import { Banner, Message } from './LocationBanner.styles'
+
+function LocationBanner() {
+  const { location } = React.useContext(DataContext)
+
+  return (
+    <Portal>
+      {!location && (
+        <Banner actions={[]} elevation={10}>
+          <Message>
+            To explore nearby parks go to Settings and allow Location access for
+            this app.
+          </Message>
+        </Banner>
+      )}
+    </Portal>
+  )
+}
+
+export default LocationBanner

--- a/src/components/LocationBanner.js
+++ b/src/components/LocationBanner.js
@@ -10,7 +10,7 @@ function LocationBanner() {
     <Portal>
       {!location && (
         <Banner actions={[]} elevation={10}>
-          <Message>
+          <Message allowFontScaling={false}>
             To explore nearby parks go to Settings and allow Location access for
             this app.
           </Message>

--- a/src/components/LocationBanner.styles.js
+++ b/src/components/LocationBanner.styles.js
@@ -1,0 +1,14 @@
+import styled from 'styled-components/native'
+import { Surface, Text } from 'react-native-paper'
+import theme from '../utils/theme'
+
+export const Banner = styled(Surface)`
+  background-color: ${theme.colors.error};
+  padding: 15px;
+  top: 60px;
+`
+
+export const Message = styled(Text)`
+  font-family: bcsans-bold;
+  color: white;
+`

--- a/src/components/LocationBanner.test.js
+++ b/src/components/LocationBanner.test.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { render, waitFor } from '@testing-library/react-native'
+import { DataProvider } from '../utils/DataContext.mock'
+import { Provider, Portal } from 'react-native-paper'
+import LocationBanner from './LocationBanner'
+
+const regex = /go to Settings/gi
+
+const Element = ({ location }) => (
+  <Provider>
+    <DataProvider value={!location ? { location: undefined } : null}>
+      <Portal.Host>
+        <LocationBanner />
+      </Portal.Host>
+    </DataProvider>
+  </Provider>
+)
+
+Element.propTypes = {
+  location: PropTypes.bool,
+}
+
+test('LocationBanner should not be visible if location available', async () => {
+  const { queryByText } = render(<Element location={true} />)
+  await waitFor(() => {
+    const banner = queryByText(regex, { exact: false })
+    expect(banner).toBeNull()
+  })
+})
+
+test('LocationBanner should be visible if no location provided', async () => {
+  const { getByText } = render(<Element location={false} />)
+  await waitFor(() => {
+    const banner = getByText(regex, { exact: false })
+    expect(banner).toBeDefined()
+  })
+})

--- a/src/pages/Explore.js
+++ b/src/pages/Explore.js
@@ -7,6 +7,7 @@ import {
 import { DataContext } from '../utils/DataContext'
 import CarouselCard from '../components/CarouselCard'
 import CarouselHeader from '../components/CarouselHeader'
+import LocationBanner from '../components/LocationBanner'
 import {
   ExplorePage,
   ExploreScrollView,
@@ -22,7 +23,9 @@ import risingSunSrc from '../../assets/sunWithShadow.png'
 function Explore() {
   const { parks, location, favoritePark } = React.useContext(DataContext)
 
-  const subheading = `Within ${defaultDistanceFilter}km of your location`
+  const subheading = location
+    ? `Within ${defaultDistanceFilter}km of your location`
+    : 'Within BC'
   const hikingParks = getClosestParksByAmenityTypeAndID(
     'activities',
     '1',
@@ -44,14 +47,19 @@ function Explore() {
 
   return (
     <ExplorePage>
-      <ExploreScrollView showsVerticalScrollIndicator={false}>
+      <LocationBanner />
+
+      <ExploreScrollView
+        showsVerticalScrollIndicator={false}
+        locationNotAvailable={!location}>
         <ExploreHeader source={headerBackgroundSrc}>
           <ExploreSvg height="70" />
           <RisingSun source={risingSunSrc} />
         </ExploreHeader>
+
         {/* Hiking - ActivityID = 1 */}
         <CarouselHeader
-          title="Great Hikes Near You"
+          title={`Great Hikes${location ? ' Near You' : ''}`}
           subheading={subheading}
           icon={'Hiking'}
         />
@@ -83,7 +91,7 @@ function Explore() {
 
         {/* Swimming - ActivityID = 3 */}
         <CarouselHeader
-          title="Swimming Holes Near You"
+          title={`Swimming Holes${location ? ' Near You' : ''}`}
           subheading={subheading}
           icon={'Swimming'}
         />
@@ -113,7 +121,7 @@ function Explore() {
 
         {/* Vehicle-Accessible Camping - FacilityID = 1 */}
         <CarouselHeader
-          title="Vehicle Camping Near You"
+          title={`Vehicle Camping${location ? ' Near You' : ''}`}
           subheading={subheading}
           icon={'Vehicle-Accessible Camping'}
         />

--- a/src/pages/Explore.styles.js
+++ b/src/pages/Explore.styles.js
@@ -15,6 +15,7 @@ export const ExplorePage = styled(SafeAreaView)`
 
 export const ExploreScrollView = styled(ScrollView)`
   flex: 1;
+  margin-top: ${(props) => (props.locationNotAvailable ? 60 : 0)}px;
 `
 
 export const ExploreHeader = styled(ImageBackground)`

--- a/src/pages/Favourites.js
+++ b/src/pages/Favourites.js
@@ -1,9 +1,10 @@
 import React from 'react'
-import haversine from 'haversine'
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons'
 import { useTheme } from 'react-native-paper'
 import { DataContext } from '../utils/DataContext'
+import { sortParks, addDistanceToParks } from '../utils/helpers'
 import ParkList from '../components/ParkList'
+import LocationBanner from '../components/LocationBanner'
 import {
   SafeArea,
   Container,
@@ -19,20 +20,14 @@ function Favourites() {
 
   const favoriteParks = parks
     .filter((park) => park.favorited)
-    .map((park) => ({
-      ...park,
-      distance: haversine(location, park.location).toFixed(0),
-    }))
-    .sort((a, b) => {
-      const distanceToA = haversine(location, a.location)
-      const distanceToB = haversine(location, b.location)
-
-      return distanceToA - distanceToB
-    })
+    .map((park) => addDistanceToParks(location, park))
+    .sort((a, b) => sortParks(location, a, b))
 
   return (
     <SafeArea>
-      <Container>
+      <LocationBanner />
+
+      <Container locationNotAvailable={!location}>
         {favoriteParks.length > 0 ? (
           <ParkList parks={favoriteParks} onFavoritePress={favoritePark} />
         ) : (

--- a/src/pages/Favourites.styles.js
+++ b/src/pages/Favourites.styles.js
@@ -11,6 +11,7 @@ export const SafeArea = styled(SafeAreaView)`
 export const Container = styled(View)`
   flex: 1;
   margin: 0 20px;
+  margin-top: ${(props) => (props.locationNotAvailable ? 60 : 0)}px;
 `
 
 export const Placeholder = styled(ScrollView)`

--- a/src/pages/Filter.js
+++ b/src/pages/Filter.js
@@ -28,6 +28,7 @@ function Filter({ navigation }) {
    */
   const [footerHeight, setFooterHeight] = React.useState(70)
   const {
+    location,
     distance,
     setDistance,
     activities,
@@ -60,12 +61,13 @@ function Filter({ navigation }) {
       <FilterScrollView
         showsVerticalScrollIndicator={false}
         footerHeight={footerHeight}>
-        <Section>
+        <Section disabled={!location}>
           <FilterTitle>Distance</FilterTitle>
           <MultiSlider
             min={1}
             max={100}
             values={[distance]}
+            enabledOne={location}
             onValuesChange={(values) => setDistance(values[0])}
             sliderLength={Dimensions.get('window').width - 55}
             containerStyle={{

--- a/src/pages/Filter.styles.js
+++ b/src/pages/Filter.styles.js
@@ -23,6 +23,7 @@ export const FilterScrollView = styled(ScrollView)`
 
 export const Section = styled(View)`
   margin: 30px 0;
+  opacity: ${(props) => (props.disabled ? 0.5 : 1)};
 `
 
 export const FilterTitle = styled(Text)`

--- a/src/pages/ParkFind.js
+++ b/src/pages/ParkFind.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import haversine from 'haversine'
 import { DataContext } from '../utils/DataContext'
+import { sortParks, addDistanceToParks } from '../utils/helpers'
 import ParkFindHeader from '../components/ParkFindHeader'
 import ParkList from '../components/ParkList'
+import LocationBanner from '../components/LocationBanner'
 import { ParkFindContainer, ParkListContainer } from './ParkFind.styles'
 
 function ParkFind({ navigation }) {
@@ -26,19 +27,12 @@ function ParkFind({ navigation }) {
   }, [searchTerm])
 
   const parks = filteredList
-    .map((park) => ({
-      ...park,
-      distance: haversine(location, park.location).toFixed(0),
-    }))
-    .sort((a, b) => {
-      const distanceToA = haversine(location, a.location)
-      const distanceToB = haversine(location, b.location)
-
-      return distanceToA - distanceToB
-    })
+    .map((park) => addDistanceToParks(location, park))
+    .sort((a, b) => sortParks(location, a, b))
 
   return (
-    <ParkFindContainer>
+    <ParkFindContainer locationNotAvailable={!location}>
+      <LocationBanner />
       <ParkFindHeader
         searchTerm={searchTerm}
         onChangeText={onChangeSearchTerm}

--- a/src/pages/ParkFind.styles.js
+++ b/src/pages/ParkFind.styles.js
@@ -4,6 +4,7 @@ import { SafeAreaView, View } from 'react-native'
 export const ParkFindContainer = styled(SafeAreaView)`
   flex: 1;
   background-color: white;
+  margin-top: ${(props) => (props.locationNotAvailable ? 60 : 0)}px;
 `
 
 export const ParkListContainer = styled(View)`

--- a/src/pages/__snapshots__/Explore.test.js.snap
+++ b/src/pages/__snapshots__/Explore.test.js.snap
@@ -15,6 +15,7 @@ exports[`Explore page matches snapshot 1`] = `
   }
 >
   <RCTScrollView
+    locationNotAvailable={false}
     showsVerticalScrollIndicator={false}
     style={
       Array [
@@ -22,6 +23,7 @@ exports[`Explore page matches snapshot 1`] = `
           "flexBasis": 0,
           "flexGrow": 1,
           "flexShrink": 1,
+          "marginTop": 0,
         },
       ]
     }

--- a/src/pages/__snapshots__/Favourites.test.js.snap
+++ b/src/pages/__snapshots__/Favourites.test.js.snap
@@ -15,6 +15,7 @@ exports[`Favourites page matches snapshot 1`] = `
   }
 >
   <View
+    locationNotAvailable={false}
     style={
       Array [
         Object {

--- a/src/pages/__snapshots__/Filter.test.js.snap
+++ b/src/pages/__snapshots__/Filter.test.js.snap
@@ -54,6 +54,7 @@ exports[`Filter page matches snapshot 1`] = `
   >
     <View>
       <View
+        disabled={false}
         style={
           Array [
             Object {
@@ -61,6 +62,7 @@ exports[`Filter page matches snapshot 1`] = `
               "marginLeft": 0,
               "marginRight": 0,
               "marginTop": 30,
+              "opacity": 1,
             },
           ]
         }
@@ -267,6 +269,7 @@ exports[`Filter page matches snapshot 1`] = `
               "marginLeft": 0,
               "marginRight": 0,
               "marginTop": 30,
+              "opacity": 1,
             },
           ]
         }
@@ -313,6 +316,7 @@ exports[`Filter page matches snapshot 1`] = `
               "marginLeft": 0,
               "marginRight": 0,
               "marginTop": 30,
+              "opacity": 1,
             },
           ]
         }

--- a/src/utils/DataContext.mock.js
+++ b/src/utils/DataContext.mock.js
@@ -2,59 +2,59 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { DataContext } from './DataContext'
 
-export function DataProvider({ children }) {
-  return (
-    <DataContext.Provider
-      value={{
-        parks: [
-          {
-            id: '361',
-            title: 'Adams Lake Provincial Park &ndash; Bush Creek Site',
-            searchableTitle: 'Adams Lake Provincial Park - Bush Creek Site',
-            location: {
-              latitude: '50.987578',
-              longitude: '-119.725971',
-            },
-            activities: [],
-            facilities: [],
-            favorited: true,
+export const DataProvider = ({ children, value }) => (
+  <DataContext.Provider
+    value={{
+      parks: [
+        {
+          id: '361',
+          title: 'Adams Lake Provincial Park &ndash; Bush Creek Site',
+          searchableTitle: 'Adams Lake Provincial Park - Bush Creek Site',
+          location: {
+            latitude: '50.987578',
+            longitude: '-119.725971',
           },
-          {
-            id: '9229',
-            title: 'Gowlland Tod Provincial Park',
-            searchableTitle: 'Gowlland Tod Provincial Park',
-            location: {
-              latitude: '48.546011',
-              longitude: '-123.509934',
-            },
-            activities: [],
-            facilities: [],
+          activities: [],
+          facilities: [],
+          favorited: true,
+        },
+        {
+          id: '9229',
+          title: 'Gowlland Tod Provincial Park',
+          searchableTitle: 'Gowlland Tod Provincial Park',
+          location: {
+            latitude: '48.546011',
+            longitude: '-123.509934',
           },
-        ],
-        location: { latitude: '48.4557', longitude: '-123.3387' },
-        distance: 100,
-        setDistance: jest.fn(),
-        activities: [
-          { id: '1', name: 'Hiking', selected: false },
-          { id: '3', name: 'Swimming', selected: false },
-        ],
-        updateActivities: jest.fn(),
-        facilities: [
-          { id: '1', name: 'Vehicle-Accessible Camping', selected: false },
-          { id: '2', name: 'Walk-In Camping', selected: false },
-        ],
-        updateFacilities: jest.fn(),
-        applyFilters: jest.fn(),
-        resetFilters: jest.fn(),
-        filteredList: [],
-        filterApplied: false,
-        favoritePark: jest.fn(),
-      }}>
-      {children}
-    </DataContext.Provider>
-  )
-}
+          activities: [],
+          facilities: [],
+        },
+      ],
+      location: { latitude: '48.4557', longitude: '-123.3387' },
+      distance: 100,
+      setDistance: jest.fn(),
+      activities: [
+        { id: '1', name: 'Hiking', selected: false },
+        { id: '3', name: 'Swimming', selected: false },
+      ],
+      updateActivities: jest.fn(),
+      facilities: [
+        { id: '1', name: 'Vehicle-Accessible Camping', selected: false },
+        { id: '2', name: 'Walk-In Camping', selected: false },
+      ],
+      updateFacilities: jest.fn(),
+      applyFilters: jest.fn(),
+      resetFilters: jest.fn(),
+      filteredList: [],
+      filterApplied: false,
+      favoritePark: jest.fn(),
+      ...value,
+    }}>
+    {children}
+  </DataContext.Provider>
+)
 
 DataProvider.propTypes = {
   children: PropTypes.object,
+  value: PropTypes.object,
 }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -104,15 +104,24 @@ export async function getParks() {
 
 export async function setLocation() {
   try {
-    const location = await Location.getCurrentPositionAsync({})
+    let permissions = await Location.getPermissionsAsync()
+    if (permissions.status !== 'granted') {
+      permissions = await Location.requestPermissionsAsync()
+    }
 
-    await AsyncStorage.setItem(
-      KEYS.location,
-      JSON.stringify({
-        latitude: location.coords.latitude,
-        longitude: location.coords.longitude,
-      })
-    )
+    if (permissions.status === 'granted') {
+      const location = await Location.getCurrentPositionAsync({})
+
+      await AsyncStorage.setItem(
+        KEYS.location,
+        JSON.stringify({
+          latitude: location.coords.latitude,
+          longitude: location.coords.longitude,
+        })
+      )
+    } else {
+      await AsyncStorage.removeItem(KEYS.location)
+    }
   } catch (error) {
     console.warn(error)
   }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -9,23 +9,16 @@ export function getClosestParksByAmenityTypeAndID(
   currentLocation,
   parks
 ) {
-  const parksByType = parks.filter(
-    (park) =>
-      park[type].includes(id) &&
-      currentLocation &&
-      haversine(currentLocation, park.location) <= defaultDistanceFilter
-  )
+  let parksByType = parks.filter((park) => park[type].includes(id))
 
   if (currentLocation) {
-    parksByType.sort((a, b) => {
-      const distanceToA = haversine(currentLocation, a.location)
-      const distanceToB = haversine(currentLocation, b.location)
-
-      return distanceToA - distanceToB
-    })
+    parksByType = parksByType.filter(
+      (park) =>
+        haversine(currentLocation, park.location) <= defaultDistanceFilter
+    )
   }
 
-  return parksByType
+  return parksByType.sort((a, b) => sortParks(currentLocation, a, b))
 }
 
 export function filterParks({
@@ -70,4 +63,25 @@ export function filterParks({
   }
 
   return filteredParks
+}
+
+export function sortParks(location, a, b) {
+  if (location) {
+    const distanceToA = haversine(location, a.location)
+    const distanceToB = haversine(location, b.location)
+    return distanceToA - distanceToB
+  } else {
+    return a.searchableTitle
+      .toUpperCase()
+      .localeCompare(b.searchableTitle.toUpperCase())
+  }
+}
+
+export function addDistanceToParks(location, park) {
+  return {
+    ...park,
+    distance: location
+      ? haversine(location, park.location).toFixed(0)
+      : 'unknown ',
+  }
 }

--- a/src/utils/helpers.test.js
+++ b/src/utils/helpers.test.js
@@ -1,17 +1,11 @@
-import { getClosestParksByAmenityTypeAndID, filterParks } from './helpers'
+import {
+  getClosestParksByAmenityTypeAndID,
+  filterParks,
+  sortParks,
+  addDistanceToParks,
+} from './helpers'
 
 const parks = [
-  {
-    id: '361',
-    title: 'Adams Lake Provincial Park &ndash; Bush Creek Site',
-    searchableTitle: 'Adams Lake Provincial Park - Bush Creek Site',
-    location: {
-      latitude: '50.987578',
-      longitude: '-119.725971',
-    },
-    activities: ['1'],
-    facilities: ['3'],
-  },
   {
     id: '9229',
     title: 'Gowlland Tod Provincial Park',
@@ -22,6 +16,17 @@ const parks = [
     },
     activities: ['1'],
     facilities: ['1'],
+  },
+  {
+    id: '361',
+    title: 'Adams Lake Provincial Park - Bush Creek Site',
+    searchableTitle: 'Adams Lake Provincial Park - Bush Creek Site',
+    location: {
+      latitude: '50.987578',
+      longitude: '-119.725971',
+    },
+    activities: ['1'],
+    facilities: ['3'],
   },
 ]
 
@@ -159,4 +164,36 @@ test('filterParks: does not return parks if they do not contain ALL indicated fa
     facilities,
   })
   expect(notContainingParks).toHaveLength(0)
+})
+
+test('sortParks sorted based on distance if location provided', () => {
+  parks.sort((a, b) => sortParks(location, a, b))
+  expect(parks[0].searchableTitle).toBe('Gowlland Tod Provincial Park')
+})
+
+test('sortParks sorted based on park name if no location provided', () => {
+  parks.sort((a, b) => sortParks(undefined, a, b))
+  expect(parks[0].searchableTitle).toBe(
+    'Adams Lake Provincial Park - Bush Creek Site'
+  )
+})
+
+test('addDistanceToParks adds distance string to park if location provided', () => {
+  const results = parks.map((park) => addDistanceToParks(location, park))
+  expect.assertions(4)
+
+  results.forEach((item) => {
+    expect(item).toHaveProperty('distance')
+    expect(parseInt(item.distance)).toEqual(expect.any(Number))
+  })
+})
+
+test("addDistanceToParks adds 'unknown'  string to park if no location provided", () => {
+  const results = parks.map((park) => addDistanceToParks(null, park))
+  expect.assertions(4)
+
+  results.forEach((item) => {
+    expect(item).toHaveProperty('distance')
+    expect(item.distance).toEqual('unknown ')
+  })
 })


### PR DESCRIPTION
I’ve added an app-wide banner that will inform the users that access to their location would be preferable for more tailored park suggestions and adjusted the behaviour slightly:
1. On the **Explore** page it won’t be filtered to only parks with 100km of the user, it will just display the parks with those amenities in alphabetical order
2. I have removed the `Near Me` from the **CarouselHeader**  and changed the subheading to just say `within BC`
3. On the **Filter** page, the distance filter slider is disabled
4. On the **ParkFind** page the parks are listed in alphabetical order
5. Anywhere within the app that a parks distance should be displayed it will now just say `unknown KM AWAY`

<kbd><img src="https://user-images.githubusercontent.com/15054821/99323072-3a7beb00-2826-11eb-845a-6f885b0ff8d4.PNG" width="250" /></kbd> <kbd><img src="https://user-images.githubusercontent.com/15054821/99322472-dd336a00-2824-11eb-9770-fbfd6a366425.PNG" width="250" /></kbd> <kbd><img src="https://user-images.githubusercontent.com/15054821/99322602-21266f00-2825-11eb-81a6-baca088b2326.PNG" width="250" /></kbd>




