### PR TITLE
Ensure favourites are preserved after data updates

### DIFF
--- a/src/pages/ParkDetails.js
+++ b/src/pages/ParkDetails.js
@@ -30,7 +30,9 @@ import {
 } from './ParkDetails.styles'
 
 function ParkDetails({ route }) {
-  const { location, activities, facilities } = React.useContext(DataContext)
+  const { location, activities, facilities, favoritePark } = React.useContext(
+    DataContext
+  )
   const { park } = route.params
   const theme = useTheme()
 
@@ -73,6 +75,8 @@ function ParkDetails({ route }) {
               name={park.favorited ? 'heart' : 'heart-outline'}
               size={20}
               color={theme.colors.secondary500}
+              onPress={() => favoritePark(park.id)}
+              accessibilityLabel="favorite park"
             />
           </TitleRow>
           <Subtitle>{`Approx. ${distance}km from your current location`}</Subtitle>

--- a/src/utils/DataContext.js
+++ b/src/utils/DataContext.js
@@ -1,6 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { getParks, getLocation, getActivities, getFacilities } from './api'
+import {
+  getParks,
+  getLocation,
+  getActivities,
+  getFacilities,
+  updateStorageFavorites,
+} from './api'
 import { defaultDistanceFilter, filterParks } from './helpers'
 
 export const DataContext = React.createContext()
@@ -77,6 +83,7 @@ export function DataProvider({ children }) {
   }
 
   function favoritePark(id) {
+    updateStorageFavorites(id)
     const index = parks.findIndex((park) => park.id === id)
     const newList = [...parks]
     newList[index].favorited = !parks[index].favorited

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -19,10 +19,16 @@ const KEYS = {
   location: 'userLocation',
   activities: 'activities',
   facilities: 'facilities',
+  favorites: 'favorites',
 }
 
 export async function fetchParks() {
   try {
+    /*
+     * Get list of existing favorites to attach to new data
+     */
+    const favorites = await getStorageFavorites()
+
     /*
      * Get unique parks and sort by the parks basic name
      */
@@ -43,7 +49,7 @@ export async function fetchParks() {
             latitude: park.Latitude,
             longitude: park.Longitude,
           },
-          favorited: false,
+          favorited: favorites.includes(park.ORCSSite),
           activities: [],
           facilities: [],
           alerts: [],
@@ -261,6 +267,31 @@ export async function fetchFacilities() {
 export async function getFacilities() {
   try {
     const data = await AsyncStorage.getItem(KEYS.facilities)
+    return data ? JSON.parse(data) : []
+  } catch (error) {
+    console.warn(error)
+  }
+}
+
+export async function updateStorageFavorites(id) {
+  try {
+    const results = await AsyncStorage.getItem(KEYS.favorites)
+    let data = results ? JSON.parse(results) : []
+
+    if (data.includes(id)) {
+      data = data.filter((item) => item !== id)
+    } else {
+      data.push(id)
+    }
+    await AsyncStorage.setItem(KEYS.favorites, JSON.stringify(data))
+  } catch (error) {
+    console.warn(error)
+  }
+}
+
+export async function getStorageFavorites() {
+  try {
+    const data = await AsyncStorage.getItem(KEYS.favorites)
     return data ? JSON.parse(data) : []
   } catch (error) {
     console.warn(error)

--- a/src/utils/api.test.js
+++ b/src/utils/api.test.js
@@ -8,6 +8,8 @@ import {
   getActivities,
   fetchFacilities,
   getFacilities,
+  getStorageFavorites,
+  updateStorageFavorites,
 } from './api'
 
 describe('parks', () => {
@@ -112,5 +114,22 @@ describe('facilities', () => {
   test('Verify getFacilities() calls AsyncStorage.getItem', async () => {
     await getFacilities()
     expect(AsyncStorage.getItem).toHaveBeenCalled()
+  })
+})
+
+describe('favorites', () => {
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
+
+  test('Verify updateStorageFavorites() adds/removes existing favorites', async () => {
+    await updateStorageFavorites('1')
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith('favorites')
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('favorites', '["1"]')
+  })
+
+  test('Verify getStorageFavorites() calls AsyncStorage.getItem', async () => {
+    await getStorageFavorites()
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith('favorites')
   })
 })


### PR DESCRIPTION
This stores a list of favourites in `AsyncStorage` so when the users exits out of the app, the next time they come in and call the api for new park data we can easily re-attaches the favourites status of parks to that new data. 