### PR TITLE
Paginate data to satisfy Android's underlying SQLlite system

### DIFF
--- a/app.json
+++ b/app.json
@@ -20,7 +20,8 @@
       "buildNumber": "0.0.5",
       "infoPlist": {
         "NSLocationWhenInUseUsageDescription": "This app uses the users location to filter their results based on proximity.",
-      }
+      },
+      "backgroundColor": "#294071",
     },
     "android": {
       "package": "ca.bcparks.parks_adventure_mobile",

--- a/app.json
+++ b/app.json
@@ -17,7 +17,7 @@
     "assetBundlePatterns": ["**/*"],
     "ios": {
       "bundleIdentifier": "ca.bcparks.parks-adventure-mobile",
-      "buildNumber": "0.0.5",
+      "buildNumber": "0.0.6",
       "infoPlist": {
         "NSLocationWhenInUseUsageDescription": "This app uses the users location to filter their results based on proximity.",
       },

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -25,6 +25,13 @@ jest.mock('@react-navigation/native', () => {
   }
 })
 
+jest.mock('@react-navigation/stack', () => {
+  return {
+    ...jest.requireActual('@react-navigation/stack'),
+    useHeaderHeight: () => 75,
+  }
+})
+
 jest.mock('react-native-paper', () => ({
   ...jest.requireActual('react-native-paper'),
   IconButton: 'Icon',

--- a/src/components/LocationBanner.js
+++ b/src/components/LocationBanner.js
@@ -1,15 +1,17 @@
 import React from 'react'
 import { DataContext } from '../utils/DataContext'
 import { Portal } from 'react-native-paper'
+import { useHeaderHeight } from '@react-navigation/stack'
 import { Banner, Message } from './LocationBanner.styles'
 
 function LocationBanner() {
+  const headerHeight = useHeaderHeight()
   const { location } = React.useContext(DataContext)
 
   return (
     <Portal>
       {!location && (
-        <Banner actions={[]} elevation={10}>
+        <Banner actions={[]} elevation={10} headerHeight={headerHeight}>
           <Message allowFontScaling={false}>
             To explore nearby parks go to Settings and allow Location access for
             this app.

--- a/src/components/LocationBanner.styles.js
+++ b/src/components/LocationBanner.styles.js
@@ -5,7 +5,7 @@ import theme from '../utils/theme'
 export const Banner = styled(Surface)`
   background-color: ${theme.colors.error};
   padding: 15px;
-  top: 60px;
+  top: ${(props) => props.headerHeight}px;
 `
 
 export const Message = styled(Text)`

--- a/src/pages/Explore.js
+++ b/src/pages/Explore.js
@@ -141,7 +141,7 @@ function Explore({ navigation }) {
               index={index}
               length={vehicleCampingParks.length}>
               <CarouselCard
-                onPress={() => setPark(park)}
+                onPress={() => navigateToPark(park)}
                 onFavoritePress={() => favoritePark(park.id)}
                 distance={
                   location

--- a/src/utils/api.test.js
+++ b/src/utils/api.test.js
@@ -17,12 +17,22 @@ describe('parks', () => {
     jest.resetAllMocks()
   })
 
-  test('Verify fetchPark() calls AsyncStorage.setItem', async () => {
+  test('Verify fetchPark() calls AsyncStorage and paginated the data', async () => {
     await fetchParks()
-    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
-      'parks',
-      expect.anything()
-    )
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('pages', '11')
+    expect(AsyncStorage.multiSet).toHaveBeenCalledWith([
+      ['parks_p.0', expect.anything()],
+      ['parks_p.1', expect.anything()],
+      ['parks_p.2', expect.anything()],
+      ['parks_p.3', expect.anything()],
+      ['parks_p.4', expect.anything()],
+      ['parks_p.5', expect.anything()],
+      ['parks_p.6', expect.anything()],
+      ['parks_p.7', expect.anything()],
+      ['parks_p.8', expect.anything()],
+      ['parks_p.9', expect.anything()],
+      ['parks_p.10', expect.anything()],
+    ])
   })
 
   test('Verify getParks() calls AsyncStorage.getItem', async () => {


### PR DESCRIPTION
Android has a 6MB limit. I do not believe we are exceeding that limit. By my estimates we are writing ~3MB of data. Nevertheless it seems to be breaking on Android so I've paginated the data to help manage this.

<img src="https://user-images.githubusercontent.com/15054821/100381313-9801fb80-2fcd-11eb-9a4d-9d207ed085b8.png" width="250" />

## Additional Changes

- Dynamically assign top value for "no location" banner
- Update `onPress` on the CarouselCard under the `Vehicle Camping Near Me` section on the Explore page
- Set `iOS` background color to helpfully "remove" white space below bottom navigation bar

<kbd><img src="https://user-images.githubusercontent.com/15054821/100381508-f4fdb180-2fcd-11eb-8886-690df9f9386f.jpg" width="250" /></kbd>